### PR TITLE
Changed github.org to github.com in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ ringio my-session output 3
 You need the Go lang development environment installed and set up:
 
 ```bash
-$ go get -u github.org/dullgiulio/ringio
+$ go get -u github.com/dullgiulio/ringio
 ```
 
 Please see [the releases page](https://github.com/dullgiulio/ringio/releases) for further information.


### PR DESCRIPTION
In README.md, I changed github.org to github.com; I was getting the error

package github.org/dullgiulio/ringio: unrecognized import path "github.org/dullgiulio/ringio"

with:
`go get -u github.org/dullgiulio/ringio`

and found that using github.com instead fixed it.
